### PR TITLE
Relax redis gem version constraint

### DIFF
--- a/redis_web_manager.gemspec
+++ b/redis_web_manager.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'pagy', '~> 3.8'
   spec.add_dependency 'rails', '>= 5.2', '< 7'
-  spec.add_dependency 'redis', '~> 4.1.0'
+  spec.add_dependency 'redis', '>= 4.1.0', '< 5'
 end


### PR DESCRIPTION
Current version of redis gem is 4.2.5 and it seems the Redis Web Manager works just fine with it :ok_hand: 