### PR TITLE
Fixing keys controller issue

### DIFF
--- a/app/controllers/redis_web_manager/application_controller.rb
+++ b/app/controllers/redis_web_manager/application_controller.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
+require 'pagy'
+require 'pagy/extras/array'
+require 'pagy/extras/bootstrap'
+
 module RedisWebManager
   class ApplicationController < ActionController::Base
+    include ::Pagy::Backend
+
     protect_from_forgery with: :exception
 
     before_action :authenticated?, if: :authenticate

--- a/app/controllers/redis_web_manager/keys_controller.rb
+++ b/app/controllers/redis_web_manager/keys_controller.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
-require 'pagy'
-require 'pagy/extras/array'
-require 'pagy/extras/bootstrap'
-
 module RedisWebManager
   class KeysController < ApplicationController
-    include ::Pagy::Backend
 
     # GET /keys
     def index


### PR DESCRIPTION
When accessing the Keys Controller after the Dashboard, it gives the following error:

`undefined method `pagy_bootstrap_nav' for #<ActionView::Base:0x007fd12874f148>`

This pull request fixes the bug