### PR TITLE
Fix large database problem

### DIFF
--- a/app/controllers/redis_web_manager/application_controller.rb
+++ b/app/controllers/redis_web_manager/application_controller.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
+require 'pagy'
+require 'pagy/extras/array'
+require 'pagy/extras/bootstrap'
+
 module RedisWebManager
   class ApplicationController < ActionController::Base
+    include ::Pagy::Backend
+
     protect_from_forgery with: :exception
 
     before_action :authenticated?, if: :authenticate

--- a/app/controllers/redis_web_manager/keys_controller.rb
+++ b/app/controllers/redis_web_manager/keys_controller.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
-require 'pagy'
-require 'pagy/extras/array'
-require 'pagy/extras/bootstrap'
-
 module RedisWebManager
   class KeysController < ApplicationController
-    include ::Pagy::Backend
 
     # GET /keys
     def index

--- a/lib/redis_web_manager/info.rb
+++ b/lib/redis_web_manager/info.rb
@@ -11,7 +11,7 @@ module RedisWebManager
     end
 
     def search(query)
-      redis.scan_each(match: "*#{query}*").to_a
+      query.blank? ? [] : redis.scan_each(match: "*#{query}*").to_a
     end
 
     def type(key)

--- a/spec/redis_web_manager_info_spec.rb
+++ b/spec/redis_web_manager_info_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe RedisWebManager::Info do
       expect(info.search('testtesttest')).to eql(['testtesttest'])
     end
 
+    it 'returns an empty array if query string is empty' do
+      expect(info.search(nil)).to eql([])
+      expect(info.search('')).to eql([])
+    end
+
     it 'returns a ttl value (expire)' do
       expect(info.expiry('test')).to eql(20)
     end


### PR DESCRIPTION
When Redis database is large it is safer to not perform any search when query string is empty